### PR TITLE
Update FullCopyingReader.java

### DIFF
--- a/src/main/java/ru/concerteza/util/io/copying/FullCopyingReader.java
+++ b/src/main/java/ru/concerteza/util/io/copying/FullCopyingReader.java
@@ -16,6 +16,9 @@ import java.io.Writer;
  * @see FullCopyingReaderTest
  */
 public class FullCopyingReader extends CopyingReader {
+    
+    private boolean closed = false;
+    
     public FullCopyingReader(Reader target, Writer copy) {
         super(target, copy);
     }
@@ -25,6 +28,8 @@ public class FullCopyingReader extends CopyingReader {
      */
     @Override
     public void close() throws IOException {
+        if (closed) return;
+        closed = true;
         IOUtils.copyLarge(source, copy);
         super.close();
     }


### PR DESCRIPTION
Inherited `Reader` documentation of `close()` method says: «Closing a previously closed stream has no effect.» But when trying to close already closed `FullCopyingReader`, `IOUtils.copyLarge(source, copy)` tries to `read` from already closed `source`, that was closed during previous `close()` call. The read causes `IOException`, such behavior is described in `Reader`'s documentation too.

This update fixes described problem.
